### PR TITLE
exchange devices

### DIFF
--- a/app/actions/instances.js
+++ b/app/actions/instances.js
@@ -166,6 +166,16 @@ var actions = {
     }
   },
 
+  RECOGNIZE_PEER_ON_HUBS: (peerId) => {
+    debug('adding peerId into active swarm', peerId)
+    connections.metaSwarm.addPeer(peerId)
+  },
+
+  IGNORE_PEER_ON_HUBS: (peerId) => {
+    debug('removing peerId from active swarm', peerId)
+    connections.metaSwarm.removePeer(peerId)
+  },
+
   REMOVE_PEER: (peerId) => {
     return (dispatch) => {
       dispatch({
@@ -185,6 +195,8 @@ var actions = {
         type: 'REMOVE_FRIEND',
         peerId
       })
+
+      actions.IGNORE_PEER_ON_HUBS(peerId)
     }
   }
 }

--- a/app/actions/instances.js
+++ b/app/actions/instances.js
@@ -44,6 +44,7 @@ var actions = {
         actions.INVITE_VALIDATED(peerId, sharedSignPubKey)(dispatch, getState)
       })
       connections.metaSwarm.on('connect', function (peer, peerId) {
+        debug('---- PEER CAME ONLINE ----', peerId)
         sync.REGISTER_PEER(peer, peerId)
       })
       connections.metaSwarm.on('disconnect', function (peer, peerId) {
@@ -151,6 +152,9 @@ var actions = {
           description: invite.description,
           peerId
         })
+        dispatch({
+          type: 'UPDATED_DEVICE_LIST'
+        })
         return
       }
 
@@ -172,6 +176,9 @@ var actions = {
       dispatch({
         type: 'REMOVE_DEVICE',
         peerId
+      })
+      dispatch({
+        type: 'UPDATED_DEVICE_LIST'
       })
 
       dispatch({

--- a/app/actions/sync.js
+++ b/app/actions/sync.js
@@ -31,7 +31,7 @@ var actions = {
 
   PROCESS_INCOMING_DATA: (data, peerId) => {
     return (dispatch, getState) => {
-      debug('processing incoming data', data)
+      debug('<< incoming data', data.type, data)
 
       var networkActions = {
         REQUEST_INVENTORY: () => {
@@ -80,6 +80,10 @@ var actions = {
 
         MULTICAST_SHARING_LEVEL: () => {
           actions.RECEIVE_SHARING_LEVEL(data.sharingLevel, peerId)(dispatch, getState)
+        },
+
+        MULTICAST_DEVICES: () => {
+          actions.RECEIVE_DEVICES(data.devices, data.deviceListVersion, peerId)(dispatch, getState)
         }
       }
 
@@ -534,9 +538,100 @@ var actions = {
 
       debug('received sharing level update from device', sharingLevel, peerId)
       dispatch({
-        type: 'SET_SHARING_LEVEL_DEVICE',
+        type: 'SET_SHARING_LEVEL',
         peerId,
         sharingLevel
+      })
+    }
+  },
+
+  START_MULTICAST_DEVICES_LOOP: (timeout, interval) => {
+    return (dispatch, getState) => {
+      window.setTimeout(multicastDevices, timeout)
+      window.setInterval(multicastDevices, interval)
+      function multicastDevices () {
+        actions.MULTICAST_DEVICES()(dispatch, getState)
+      }
+    }
+  },
+
+  MULTICAST_DEVICES: () => {
+    return (dispatch, getState) => {
+      var devices = getState().devices
+      var friends = getState().friends
+
+      debug('multicasting devices to devices', friends)
+      devices.forEach((device) => {
+        peers.send({
+          type: 'MULTICAST_DEVICES',
+          devices,
+          deviceListVersion: getState().sync.deviceListVersion
+        }, device.peerId)
+      })
+    }
+  },
+
+  RECEIVE_DEVICES: (receivedDevices, deviceListVersion, peerId) => {
+    return (dispatch, getState) => {
+      if (deviceListVersion <= getState().sync.deviceListVersion) {
+        debug('received a device list not newer than mine - skipping')
+        return
+      }
+
+      var myId = getState().instances.keyPair.publicKey
+      var devices = getState().devices
+
+      function isOwnDevice (peerId) {
+        return devices.some((device) => {
+          return device.peerId === peerId
+        })
+      }
+
+      if (!isOwnDevice(peerId)) {
+        debug('only own devices are allowed to update friends list - skipping', peerId)
+        return
+      }
+
+      var removedDevices = devices.slice()
+
+      receivedDevices.forEach((receivedDevice) => {
+        if (receivedDevice.peerId === myId) return
+
+        var index = devices.findIndex((device) => device.peerId === receivedDevice.peerId)
+
+        if (index !== -1) {
+          removedDevices.splice(index, 1)
+          return
+        }
+
+        debug('got informed of a new device - adding', receivedDevice.peerId)
+
+        dispatch({
+          type: 'WEBRTC_WHITELIST_ADD',
+          peerId: receivedDevice.peerId
+        })
+        dispatch({
+          type: 'ADD_DEVICE',
+          ...receivedDevice
+        })
+      })
+
+      removedDevices.forEach((removedDevice) => {
+        if (removedDevice.peerId === peerId) return
+
+        dispatch({
+          type: 'WEBRTC_WHITELIST_REMOVE',
+          peerId: removedDevice.peerId
+        })
+        dispatch({
+          type: 'REMOVE_DEVICE',
+          peerId: removedDevice.peerId
+        })
+      })
+
+      dispatch({
+        type: 'UPDATED_DEVICE_LIST',
+        version: deviceListVersion
       })
     }
   }
@@ -638,7 +733,7 @@ function Peers (dispatch, getState) {
   }
 
   self.send = (data, peerId) => {
-    debug('sending to peer', peerId, data.type)
+    debug('>> sending to peer', data.type, data, peerId)
     var sharingLevel = getState().sync.sharingLevel
     var devices = getState().devices
 
@@ -653,7 +748,7 @@ function Peers (dispatch, getState) {
   }
 
   self.broadcast = (data) => {
-    debug('broadcasting to ' + Object.keys(self.remotes).length + ' peers', data.type)
+    debug('>> >> broadcasting to ' + Object.keys(self.remotes).length + ' peers', data.type)
     var sharingLevel = getState().sync.sharingLevel
     var devices = getState().devices
 

--- a/app/actions/sync.js
+++ b/app/actions/sync.js
@@ -614,6 +614,7 @@ var actions = {
           type: 'ADD_DEVICE',
           ...receivedDevice
         })
+        require('./instances').RECOGNIZE_PEER_ON_HUBS(receivedDevice.peerId)
       })
 
       removedDevices.forEach((removedDevice) => {
@@ -627,6 +628,7 @@ var actions = {
           type: 'REMOVE_DEVICE',
           peerId: removedDevice.peerId
         })
+        require('./instances').IGNORE_PEER_ON_HUBS(removedDevice.peerId)
       })
 
       dispatch({

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -10,7 +10,7 @@ const thunk = require('redux-thunk')
 const reduxStorage = require('redux-storage')
 const storageEngine = require('redux-storage/engines/localStorage').default('peermusic-storage')
 const { PLAYER_SYNCHRONIZE, RESET_IMPORTING_SONGS, INSTANCES_CONNECT, INITIATE_SYNC,
-  INITIALLY_LOAD_COVERS, START_DOWNLOAD_LOOP, START_SHARING_LEVEL_SYNC_LOOP, LOAD_THEME } = require('./actions')
+  INITIALLY_LOAD_COVERS, START_DOWNLOAD_LOOP, START_SHARING_LEVEL_SYNC_LOOP, START_MULTICAST_DEVICES_LOOP, LOAD_THEME } = require('./actions')
 
 // Enforce the user to use SSL if used via github pages
 if (window.location.host === 'peermusic.github.io' && window.location.protocol === 'http:') {
@@ -46,6 +46,7 @@ load(store).then(() => {
 
   START_DOWNLOAD_LOOP(1000 * 5, 1000 * 60 * 1)(store.dispatch, store.getState)
   START_SHARING_LEVEL_SYNC_LOOP(1000 * 5, 1000 * 60 * 1)(store.dispatch, store.getState)
+  START_MULTICAST_DEVICES_LOOP(1000 * 3, 1000 * 5)(store.dispatch, store.getState)
   LOAD_THEME()(store.dispatch, store.getState)
 })
 

--- a/app/reducers/devices.js
+++ b/app/reducers/devices.js
@@ -8,8 +8,8 @@ const device = (state = {}, action) => {
         peerId: action.peerId,
         sharingLevel: action.sharingLevel
       }
-    case 'SET_SHARING_LEVEL_DEVICE':
-      if (action.peerId !== state.peerId) return
+    case 'SET_SHARING_LEVEL':
+      if (state.peerId !== action.peerId) return state
 
       return {
         ...state,
@@ -26,10 +26,11 @@ const devices = (state = [], action) => {
       debug('adding device')
       return [...state, device(undefined, action)]
     case 'REMOVE_DEVICE':
-      var index = state.findIndex((device) => device.peerId = action.peerId)
+      console.log('REMOVE_DEVICE', action.peerId, '')
+      var index = state.findIndex((device) => device.peerId === action.peerId)
       if (index === -1) return state
       return [...state.slice(0, index), ...state.slice(index + 1)]
-    case 'SET_SHARING_LEVEL_DEVICE':
+    case 'SET_SHARING_LEVEL':
       return state.map(s => device(s, action))
     default:
       return state

--- a/app/reducers/instances.js
+++ b/app/reducers/instances.js
@@ -56,6 +56,7 @@ const instances = (state = initialState, action) => {
     },
 
     WEBRTC_WHITELIST_ADD: () => {
+      if (state.whitelist.indexOf(action.peerId) !== -1) return state
       return {...state, whitelist: [...state.whitelist, action.peerId]}
     },
 

--- a/app/reducers/sync.js
+++ b/app/reducers/sync.js
@@ -5,7 +5,8 @@ const initialState = {
   sharingLevel: 'FRIENDS',
   forFriends: [],
   allowedPendingDownloadsForFriends: 50,
-  bannedSongs: []
+  bannedSongs: [],
+  deviceListVersion: 0
 }
 
 module.exports = (state = initialState, action) => {
@@ -42,6 +43,12 @@ module.exports = (state = initialState, action) => {
 
     'REMOVE_BAN': () => {
       return {...state, bannedSongs: state.bannedSongs.filter(x => x.id !== action.id)}
+    },
+
+    'UPDATED_DEVICE_LIST': () => {
+      return {...state, deviceListVersion: action.version
+        ? action.version
+        : state.deviceListVersion + 1}
     }
   }
 


### PR DESCRIPTION
- [x] keep a versioned device list that gets broadcasted regularly among devices.
- [x] when adding/removing devices update the list version.
- [x] inject new peers into existing swarm when adding so that no restart is needed to connect.

**_Testing**_
1. Open three Peermusic instances
2. In instance 2 generate _device_ invites for 1 and 3.
3. Add invites in 1 and 3.
4. Wait... see that 3 knows about 1 and vice versa.
5. Close 2.
6. Remove device 2 in instance 3.
7. Wait... see that 1 does no longer knows about 2.

---

See: peermusic/user-stories/issues/87
