### PR TITLE
chunk all outgoing objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "classnames": "^2.2.1",
     "connect-instances": "git+https://github.com/peermusic/connect-instances.git",
     "create-torrent": "^3.20.3",
+    "cuid": "^1.3.8",
     "debug": "^2.2.0",
     "file-system": "git+https://github.com/peermusic/file-system.git",
     "history": "^1.17.0",


### PR DESCRIPTION
This should fix the problem that music inventory objects can become too big.

---

See: peermusic/user-stories/issues/111
